### PR TITLE
Remove provider blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,4 @@
 module "acm_certificate" {
-  providers = {
-    aws = aws.global
-  }
-
   source  = "operatehappy/acm-certificate/aws"
   version = "1.2.0"
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,4 @@
 provider "aws" {
-  region = "us-east-1"
-}
-
-provider "aws" {
   alias  = "global"
   region = "us-east-1"
 }


### PR DESCRIPTION
Fixes an AWS provider issue when using the module 

```text
Error: error configuring Terraform AWS Provider: no valid credential sources for Terraform AWS Provider found.
```